### PR TITLE
add geogratis geocoder service

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ Geocode streaming CSV data, producing CSV or GeoJSON.
 * Worldwide
 * Coarse (not street-level)
 
+`geogratis`: [Geogratis](http://geogratis.gc.ca/site/eng/geoloc)
+
+* Canada-Only
+* Unforgiving address input format, see [Geogratis] for details.
+
 ## options
 
 The input is either the first positional argument, like

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Geocode streaming CSV data, producing CSV or GeoJSON.
 `geogratis`: [Geogratis](http://geogratis.gc.ca/site/eng/geoloc)
 
 * Canada-Only
-* Unforgiving address input format, see [Geogratis] for details.
+* Unforgiving address input format, see [service documentation](http://geogratis.gc.ca/site/eng/geoloc) for details.
 
 ## options
 

--- a/index.js
+++ b/index.js
@@ -32,6 +32,27 @@ var sources = {
                 encodeURIComponent(address) + '.json';
         }
     },
+    geogratis: function geocode(address, callback) {
+        http.get(geocodeUrl(address), function(res) {
+            res.pipe(concat(function(buf) {
+                var data = JSON.parse(buf);
+                if (data && data.length > 0) {
+                    callback(null, {
+                        lat: data[0].geometry.coordinates[1],
+                        lon: data[0].geometry.coordinates[0]
+                    });
+                } else {
+                    callback('no result');
+                }
+            }));
+        });
+        function geocodeUrl(address) {
+            return 'http://geogratis.gc.ca/services/geolocation/en/locate?q=' +
+                encodeURIComponent(address)
+                    // Geogratis' address format isn't very forgiving...
+                    .replace(/canada/i, '').trim();
+        }
+    },
     census: function geocode(address, callback) {
         http.get(geocodeUrl(address), function(res) {
             res.pipe(concat(function(buf) {


### PR DESCRIPTION
Quick follow-up to #5.

Geogratis doesn't like country name or postal code to be included in the address. It would be useful to be able to provide a service-specific address transform function.

Also, I get errors from the passthrough stream when output is set to CSV. However that seems to happen regardless of what geocoder service is used.
